### PR TITLE
Install a relevant version of docker-engine-selinux

### DIFF
--- a/1.10.3.sh
+++ b/1.10.3.sh
@@ -445,12 +445,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.11.2.sh
+++ b/1.11.2.sh
@@ -445,12 +445,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.12.1.sh
+++ b/1.12.1.sh
@@ -485,12 +485,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.12.2.sh
+++ b/1.12.2.sh
@@ -485,12 +485,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.12.3.sh
+++ b/1.12.3.sh
@@ -485,12 +485,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.12.4.sh
+++ b/1.12.4.sh
@@ -486,12 +486,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.12.5.sh
+++ b/1.12.5.sh
@@ -486,12 +486,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.12.6.sh
+++ b/1.12.6.sh
@@ -486,12 +486,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.13.0.sh
+++ b/1.13.0.sh
@@ -486,12 +486,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot

--- a/1.13.1.sh
+++ b/1.13.1.sh
@@ -486,12 +486,12 @@ do_install() {
 			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
 				(
 					set -x
-					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; dnf -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			else
 				(
 					set -x
-					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version}"
+					$sh_c "sleep 3; yum -y -q install docker-engine-${docker_version} docker-engine-selinux-${docker_version}"
 				)
 			fi
 			echo_docker_as_nonroot


### PR DESCRIPTION
Without this PR one would have a non-relevant version of the docker-engine-selinux installed.

Example:

```
[centos@centos-worker1 ~]$ curl https://releases.rancher.com/install-docker/1.12.sh | sh
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
100 16609 100 16609 0 0 63175 0 --:--:-- --:--:-- --:--:-- 63636
+ sudo -E sh -c 'sleep 3; yum -y -q install docker-engine-1.12.6'
warning: /var/cache/yum/x86_64/7/base/packages/libseccomp-2.3.1-2.el7.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID f4a80eb5: NOKEY
Public key for libseccomp-2.3.1-2.el7.x86_64.rpm is not installed
Public key for libtool-ltdl-2.4.2-22.el7_3.x86_64.rpm is not installed
warning: /var/cache/yum/x86_64/7/docker-main-repo/packages/docker-engine-selinux-17.05.0.ce-1.el7.centos.noarch.rpm: Header V4 RSA/SHA512 Signature, key ID 2c52609d: NOKEY
Public key for docker-engine-selinux-17.05.0.ce-1.el7.centos.noarch.rpm is not installed
Importing GPG key 0x2C52609D:
Userid : "Docker Release Tool (releasedocker) <docker@docker.com>"
Fingerprint: 5811 8e89 f3a9 1289 7c07 0adb f762 2157 2c52 609d
From : https://yum.dockerproject.org/gpg
Importing GPG key 0xF4A80EB5:
Userid : "CentOS-7 Key (CentOS 7 Official Signing Key) <security@centos.org>"
Fingerprint: 6341 ab27 53d7 8a78 a7c2 7bb1 24c6 a8a7 f4a8 0eb5
Package : centos-release-7-3.1611.el7.centos.x86_64 (installed)
From : /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
libsemanage.semanage_direct_install_info: Overriding docker module at lower priority 100 with module at priority 400.
restorecon: lstat(/var/lib/docker) failed: No such file or directory
warning: %post(docker-engine-selinux-17.05.0.ce-1.el7.centos.noarch) scriptlet failed, exit status 255
Non-fatal POSTIN scriptlet failure in rpm package docker-engine-selinux-17.05.0.ce-1.el7.centos.noarch

If you would like to use Docker as a non-root user, you should now consider
adding your user to the "docker" group with something like:

sudo usermod -aG docker centos

Remember that you will have to log out and back in for this to take effect!

[centos@centos-worker1 ~]$ echo $?
0
[centos@centos-worker1 ~]$ rpm -qa |grep -i docker
docker-engine-1.12.6-1.el7.centos.x86_64
docker-engine-selinux-17.05.0.ce-1.el7.centos.noarch

[centos@centos-worker1 ~]$ sudo -i
[root@centos-worker1 ~]# cat /var/log/yum.log 
Aug 02 08:27:56 Installed: docker-engine-selinux-17.05.0.ce-1.el7.centos.noarch
Aug 02 08:27:59 Installed: libseccomp-2.3.1-2.el7.x86_64
Aug 02 08:27:59 Installed: libtool-ltdl-2.4.2-22.el7_3.x86_64
Aug 02 08:28:04 Installed: docker-engine-1.12.6-1.el7.centos.x86_64
```

And one would need to downgrade if he wants a corresponding version of the docker-engine-selinux package:

```
[root@centos-worker1 ~]# yum downgrade docker-engine-selinux-1.12.6-1.el7.centos
[root@centos-worker1 ~]# rpm -qa |grep docker
docker-engine-1.12.6-1.el7.centos.x86_64
docker-engine-selinux-1.12.6-1.el7.centos.noarch
```

Not sure how is the situation with Debian-based distros.
Let me know so I can update the PR.