### PR TITLE
add a force-yes, as 17.03.2 is likely to be a downgrade

### DIFF
--- a/17.03.2.sh
+++ b/17.03.2.sh
@@ -369,7 +369,7 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				$sh_c "apt-get install -y -q --allow-downgrades docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
 			)
 			echo_docker_as_nonroot
 			exit 0


### PR DESCRIPTION
I was going to try something with 17.03, but got this failure:

```
+ sudo -E sh -c apt-get install -y -q docker-ce=17.03.2~ce-0~debian-jessie
Reading package lists...
Building dependency tree...
Reading state information...
The following packages were automatically installed and are no longer required:
  dkms html2text libdns88 libdrm-nouveau1a libffi5 libgssglue1 libicu48 libisc84 libisccc80 libisccfg82 libkadm5clnt-mit8 libkdb5-6 liblwres80 libplrpc-perl
  librtmp0 linux-headers-3.2.0-4-amd64 linux-headers-3.2.0-4-common linux-headers-amd64 linux-image-3.2.0-4-amd64 linux-kbuild-3.2 menu open-vm-dkms
  openssh-blacklist openssh-blacklist-extra python-fpconst ttf-dejavu-core
Use 'apt-get autoremove' to remove them.
The following extra packages will be installed:
  libapparmor1
Recommended packages:
  aufs-tools cgroupfs-mount cgroup-lite
The following NEW packages will be installed:
  libapparmor1
The following packages will be DOWNGRADED:
  docker-ce
0 upgraded, 1 newly installed, 1 downgraded, 0 to remove and 1 not upgraded.
Need to get 19.0 MB of archives.
After this operation, 96.8 MB disk space will be freed.
E: There are problems and -y was used without --force-yes

```

@vincent99 I'm presuming this applies to all scripts

and ubuntu fails to downgrade too - but that'll require more investigation