### PR TITLE
Fix RancherOS switch docker engine failed bug

### DIFF
--- a/1.13.1.sh
+++ b/1.13.1.sh
@@ -527,7 +527,11 @@ do_install() {
 		rancheros)
 			(
 			set -x
-			$sh_c "sleep 3; ros engine switch -f $(sudo ros engine list | grep ${docker_version} | head -n 1 | cut -d ' ' -f 2)"
+			$sh_c "sleep 3;ros engine list --update"
+			engine_version="$(sudo ros engine list | awk '{print $2}' | grep ${docker_version} | tail -n 1)"
+			if [ "$engine_version" != "" ]; then
+				$sh_c "ros engine switch -f $engine_version"
+			fi
 			)
 			exit 0
 			;;

--- a/17.03.2.sh
+++ b/17.03.2.sh
@@ -498,7 +498,11 @@ do_install() {
 		rancheros)
 			(
 			set -x
-			$sh_c "sleep 3; ros engine switch -f $(sudo ros engine list | grep ${docker_version} | head -n 1 | cut -d ' ' -f 2)"
+			$sh_c "sleep 3;ros engine list --update"
+			engine_version="$(sudo ros engine list | awk '{print $2}' | grep ${docker_version} | tail -n 1)"
+			if [ "$engine_version" != "" ]; then
+				$sh_c "ros engine switch -f $engine_version"
+			fi
 			)
 			exit 0
 			;;

--- a/17.06.2.sh
+++ b/17.06.2.sh
@@ -498,7 +498,11 @@ do_install() {
 		rancheros)
 			(
 			set -x
-			$sh_c "sleep 3; ros engine switch -f $(sudo ros engine list | grep ${docker_version} | head -n 1 | cut -d ' ' -f 2)"
+			$sh_c "sleep 3;ros engine list --update"
+			engine_version="$(sudo ros engine list | awk '{print $2}' | grep ${docker_version} | tail -n 1)"
+			if [ "$engine_version" != "" ]; then
+				$sh_c "ros engine switch -f $engine_version"
+			fi
 			)
 			exit 0
 			;;

--- a/18.06.3.sh
+++ b/18.06.3.sh
@@ -502,7 +502,11 @@ do_install() {
 		rancheros)
 			(
 			set -x
-			$sh_c "sleep 3; ros engine switch -f $(sudo ros engine list | grep ${docker_version} | head -n 1 | cut -d ' ' -f 2)"
+			$sh_c "sleep 3;ros engine list --update"
+			engine_version="$(sudo ros engine list | awk '{print $2}' | grep ${docker_version} | tail -n 1)"
+			if [ "$engine_version" != "" ]; then
+				$sh_c "ros engine switch -f $engine_version"
+			fi
 			)
 			exit 0
 			;;

--- a/18.09.6.sh
+++ b/18.09.6.sh
@@ -502,7 +502,11 @@ do_install() {
 		rancheros)
 			(
 			set -x
-			$sh_c "sleep 3; ros engine switch -f $(sudo ros engine list | grep ${docker_version} | head -n 1 | cut -d ' ' -f 2)"
+			$sh_c "sleep 3;ros engine list --update"
+			engine_version="$(sudo ros engine list | awk '{print $2}' | grep ${docker_version} | tail -n 1)"
+			if [ "$engine_version" != "" ]; then
+				$sh_c "ros engine switch -f $engine_version"
+			fi
 			)
 			exit 0
 			;;

--- a/18.09.7.sh
+++ b/18.09.7.sh
@@ -502,7 +502,11 @@ do_install() {
 		rancheros)
 			(
 			set -x
-			$sh_c "sleep 3; ros engine switch -f $(sudo ros engine list | grep ${docker_version} | head -n 1 | cut -d ' ' -f 2)"
+			$sh_c "sleep 3;ros engine list --update"
+			engine_version="$(sudo ros engine list | awk '{print $2}' | grep ${docker_version} | tail -n 1)"
+			if [ "$engine_version" != "" ]; then
+				$sh_c "ros engine switch -f $engine_version"
+			fi
 			)
 			exit 0
 			;;

--- a/18.09.8.sh
+++ b/18.09.8.sh
@@ -502,7 +502,11 @@ do_install() {
 		rancheros)
 			(
 			set -x
-			$sh_c "sleep 3; ros engine switch -f $(sudo ros engine list | grep ${docker_version} | head -n 1 | cut -d ' ' -f 2)"
+			$sh_c "sleep 3;ros engine list --update"
+			engine_version="$(sudo ros engine list | awk '{print $2}' | grep ${docker_version} | tail -n 1)"
+			if [ "$engine_version" != "" ]; then
+				$sh_c "ros engine switch -f $engine_version"
+			fi
 			)
 			exit 0
 			;;

--- a/19.03.1.sh
+++ b/19.03.1.sh
@@ -502,7 +502,11 @@ do_install() {
 		rancheros)
 			(
 			set -x
-			$sh_c "sleep 3; ros engine switch -f $(sudo ros engine list | grep ${docker_version} | head -n 1 | cut -d ' ' -f 2)"
+			$sh_c "sleep 3;ros engine list --update"
+			engine_version="$(sudo ros engine list | awk '{print $2}' | grep ${docker_version} | tail -n 1)"
+			if [ "$engine_version" != "" ]; then
+				$sh_c "ros engine switch -f $engine_version"
+			fi
 			)
 			exit 0
 			;;


### PR DESCRIPTION
**Problem**
1.  When the local version is the same as the specified version the docker engine will be switched failed.
2. When the local cache doesn't have the specified version the docker engine will be switched failed.

**Solutions**
1. Modify the shell script to get the docker engine version correctly.
2. Execute `ros engine list --update` first to update the local cache.
3. When the script can't get the docker engine version by the specified version, just use the default docker engine.

Only modified the versions which users can select in Rancher UI.

**Related Issue**:
https://github.com/rancher/os/issues/2808

