### PR TITLE
Pin ubuntu/debian docker-ce-cli package version to docker-ce version

### DIFF
--- a/18.09.0.sh
+++ b/18.09.0.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.1.sh
+++ b/18.09.1.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.2.sh
+++ b/18.09.2.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.3.sh
+++ b/18.09.3.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.4.sh
+++ b/18.09.4.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.5.sh
+++ b/18.09.5.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.6.sh
+++ b/18.09.6.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.7.sh
+++ b/18.09.7.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+                pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.8.sh
+++ b/18.09.8.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/18.09.9.sh
+++ b/18.09.9.sh
@@ -373,7 +373,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.0.sh
+++ b/19.03.0.sh
@@ -374,7 +374,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.1.sh
+++ b/19.03.1.sh
@@ -374,7 +374,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.2.sh
+++ b/19.03.2.sh
@@ -374,7 +374,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.3.sh
+++ b/19.03.3.sh
@@ -374,7 +374,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.4.sh
+++ b/19.03.4.sh
@@ -374,7 +374,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.5.sh
+++ b/19.03.5.sh
@@ -378,7 +378,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.7.sh
+++ b/19.03.7.sh
@@ -374,7 +374,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.8.sh
+++ b/19.03.8.sh
@@ -374,7 +374,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0

--- a/19.03.9.sh
+++ b/19.03.9.sh
@@ -374,7 +374,8 @@ do_install() {
 					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
 				fi
 				$sh_c 'apt-get update'
-				$sh_c "apt-get install -y -q docker-ce=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)"
+				pkg_version=$(apt-cache madison docker-ce | grep ${docker_version} | head -n 1 | cut -d ' ' -f 4)
+				$sh_c "apt-get install -y -q docker-ce=${pkg_version} docker-ce-cli=${pkg_version}"
 			)
 			echo_docker_as_nonroot
 			exit 0


### PR DESCRIPTION
docker-ce-cli was introduced as an additional package and a dependency of docker-ce with 18.09.

Without pinning the newest docker-ce-cli will be installed. Starting with 19.03.9 the docker-ce-cli version does not work anymore with older docer-ce 18.09 versions.

Error message: Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39

https://github.com/rancher/rancher/issues/27161