### PR TITLE
Pin centos|fedora|redhat|oraclelinux docker-ce-cli package version to docker-ce version

### DIFF
--- a/18.09.0.sh
+++ b/18.09.0.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.1.sh
+++ b/18.09.1.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.2.sh
+++ b/18.09.2.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.3.sh
+++ b/18.09.3.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.4.sh
+++ b/18.09.4.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.5.sh
+++ b/18.09.5.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.6.sh
+++ b/18.09.6.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.7.sh
+++ b/18.09.7.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.8.sh
+++ b/18.09.8.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/18.09.9.sh
+++ b/18.09.9.sh
@@ -409,7 +409,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.0.sh
+++ b/19.03.0.sh
@@ -410,7 +410,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.1.sh
+++ b/19.03.1.sh
@@ -410,7 +410,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.2.sh
+++ b/19.03.2.sh
@@ -410,7 +410,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.3.sh
+++ b/19.03.3.sh
@@ -410,7 +410,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.4.sh
+++ b/19.03.4.sh
@@ -410,7 +410,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.5.sh
+++ b/19.03.5.sh
@@ -414,7 +414,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.7.sh
+++ b/19.03.7.sh
@@ -410,7 +410,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.8.sh
+++ b/19.03.8.sh
@@ -410,7 +410,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else

--- a/19.03.9.sh
+++ b/19.03.9.sh
@@ -410,7 +410,7 @@ do_install() {
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache fast"
-				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}"
+				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version} docker-ce-cli-${docker_version}"
 				if [ -d '/run/systemd/system' ]; then
 					$sh_c 'service docker start'
 				else


### PR DESCRIPTION
docker-ce-cli was introduced as an additional package and a dependency of docker-ce with 18.09.

Without pinning the newest docker-ce-cli will be installed. Starting with 19.03.9 the docker-ce-cli version does not work anymore with older docer-ce 18.09 versions.

Error message: Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39

https://github.com/rancher/rancher/issues/27161

PR for ubuntu/debian https://github.com/rancher/install-docker/pull/47