### PR TITLE
Backport EL path fix to older versions

### DIFF
--- a/17.03.0.sh
+++ b/17.03.0.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q --setopt=obsoletes=0 docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/17.03.1.sh
+++ b/17.03.1.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q --setopt=obsoletes=0 docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/17.03.2.sh
+++ b/17.03.2.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q --setopt=obsoletes=0 docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/17.06.0.sh
+++ b/17.06.0.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/17.06.1.sh
+++ b/17.06.1.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/17.06.2.sh
+++ b/17.06.2.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/17.09.0.sh
+++ b/17.09.0.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/17.12.0.sh
+++ b/17.12.0.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/17.12.1.sh
+++ b/17.12.1.sh
@@ -142,6 +142,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -404,6 +426,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/18.03.0.sh
+++ b/18.03.0.sh
@@ -143,6 +143,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -405,6 +427,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then

--- a/18.03.1.sh
+++ b/18.03.1.sh
@@ -143,6 +143,28 @@ deprecation_notice() {
 	sleep 10;
 }
 
+adjust_repo_releasever() {
+	DOWNLOAD_URL="https://download.docker.com"
+	case $1 in
+	7*)
+		releasever=7
+		;;
+	8*)
+		releasever=8
+		;;
+	*)
+		# fedora, or unsupported
+		return
+		;;
+	esac
+
+	for channel in "stable" "test" "nightly"; do
+		$sh_c "$config_manager --setopt=docker-ce-${channel}.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-debuginfo.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/debug-\\\$basearch/${channel} --save";
+		$sh_c "$config_manager --setopt=docker-ce-${channel}-source.baseurl=${DOWNLOAD_URL}/linux/centos/${releasever}/source/${channel} --save";
+	done
+}
+
 do_install() {
 
 	architecture=$(uname -m)
@@ -405,6 +427,7 @@ do_install() {
 					echo "Info: Enabling channel '$CHANNEL' for docker-ce repo"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
+				adjust_repo_releasever "$dist_version"
 				$sh_c "$pkg_manager makecache fast"
 				$sh_c "$pkg_manager install -y -q docker-ce-${docker_version}.ce"
 				if [ -d '/run/systemd/system' ]; then


### PR DESCRIPTION
Backport (https://github.com/rancher/rancher/issues/29246) to older versions to make sure the packages on the changed server path on download.docker.com can be found. Part of a fix for https://github.com/rancher/rancher/issues/29749