### PR TITLE
Backport enabling available RHEL repos

### DIFF
--- a/17.03.0.sh
+++ b/17.03.0.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/17.03.1.sh
+++ b/17.03.1.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/17.03.2.sh
+++ b/17.03.2.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/17.06.0.sh
+++ b/17.06.0.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/17.06.1.sh
+++ b/17.06.1.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/17.06.2.sh
+++ b/17.06.2.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/17.09.0.sh
+++ b/17.09.0.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/17.12.0.sh
+++ b/17.12.0.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/17.12.1.sh
+++ b/17.12.1.sh
@@ -16,8 +16,10 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
+rhui-rhel-7-for-arm-64-extras-rhui-rpms
 "
 
 mirror=''

--- a/18.03.0.sh
+++ b/18.03.0.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.03.1.sh
+++ b/18.03.1.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.06.0.sh
+++ b/18.06.0.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.06.1.sh
+++ b/18.06.1.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.06.2.sh
+++ b/18.06.2.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.06.3.sh
+++ b/18.06.3.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.0.sh
+++ b/18.09.0.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.1.sh
+++ b/18.09.1.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.2.sh
+++ b/18.09.2.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.3.sh
+++ b/18.09.3.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.4.sh
+++ b/18.09.4.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.5.sh
+++ b/18.09.5.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.6.sh
+++ b/18.09.6.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.7.sh
+++ b/18.09.7.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.8.sh
+++ b/18.09.8.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms

--- a/18.09.9.sh
+++ b/18.09.9.sh
@@ -16,6 +16,7 @@ keyserver.ubuntu.com
 
 rhel_repos="
 rhel-7-server-extras-rpms
+rhel-7-server-rhui-extras-rpms
 rhui-REGION-rhel-server-extras
 rhui-rhel-7-server-rhui-extras-rpms
 rhui-rhel-7-for-arm-64-extras-rhui-rpms


### PR DESCRIPTION
The to-enable RHEL repos have changed over the years but never backported to older version while they are still used for validation by QA. This syncs them all back for the "LTS" versions (03,06,09,12)

Part of a fix for https://github.com/rancher/rancher/issues/29749