### PR TITLE
Add drone automated publishing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,21 @@ platform:
   arch: amd64
 
 steps:
+  - name: validate
+    image: rancher/dapper:v0.5.4
+    commands:
+    - 'find ./dist -name \*.sh -exec sh -n {} \;'
+    volumes:
+    - name: docker
+      path: /var/run/docker.sock
+    when:
+      branch:
+      - master
+      event:
+      - push
+      - pull_request
+      - tag
+
   - name: test
     image: rancher/dapper:v0.5.4
     commands:
@@ -20,6 +35,74 @@ steps:
       event:
       - push
       - pull_request
+      - tag
+
+  - name: add-commit-to-version-file
+    image: rancher/dapper:v0.5.4
+    commands:
+    - "echo ${DRONE_COMMIT} > dist/VERSION"
+    volumes:
+    - name: docker
+      path: /var/run/docker.sock
+    when:
+      branch:
+      - master
+      event:
+      - push
+
+  - name: upload-dev
+    pull: default
+    image: plugins/gcs
+    settings:
+      acl:
+      - allUsers:READER
+      cache_control: "public,no-cache,proxy-revalidate"
+      source: dist/
+      ignore: ".gitkeep"
+      target: releases.rancher.com/install-docker-dev
+      token:
+        from_secret: google_auth_key
+    when:
+      instance:
+        include:
+        - drone-publish.rancher.io
+      branch:
+      - master
+      event:
+      - push
+
+  - name: add-tag-to-version-file
+    image: rancher/dapper:v0.5.4
+    commands:
+    - "echo ${DRONE_TAG} > dist/VERSION"
+    volumes:
+    - name: docker
+      path: /var/run/docker.sock
+    when:
+      branch:
+      - master
+      event:
+      - tag
+
+  - name: upload
+    pull: default
+    image: plugins/gcs
+    settings:
+      acl:
+      - allUsers:READER
+      cache_control: "public,no-cache,proxy-revalidate"
+      source: dist/
+      ignore: ".gitkeep"
+      target: releases.rancher.com/install-docker
+      token:
+        from_secret: google_auth_key
+    when:
+      instance:
+        include:
+        - drone-publish.rancher.io
+      branch:
+      - master
+      event:
       - tag
 
 volumes:


### PR DESCRIPTION
The flow is:

- Check if shell is valid (basically parseable)
- Add current commit to `dist/VERSION` to track what is uploaded (for install-docker-dev)
- Upload to install-docker-dev on GCS
- If released (tag), add tag to `dist/VERSION`
- If released (tag), upload to install-docker on GCS

This flow allows to have sanity check on the scripts, upload to a non production location (install-docker-dev), have it tested (by ourselves and by QA), then promote it using a tag. By adding the commit/tag to the release, we can also always be sure what is currently live. This is combination with the PR to check if Docker actually can be installed (which is basically a repo/package check), its fairly solid.

I'm thinking to also upload a CHECKSUMS file with all the scripts checksum if someone wants to validate that (although its coming from the same source but some people want it)