### PR TITLE
Fix for Debian Buster w/o lsb-release

### DIFF
--- a/18.09.0.sh
+++ b/18.09.0.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+			    10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.1.sh
+++ b/18.09.1.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.2.sh
+++ b/18.09.2.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.3.sh
+++ b/18.09.3.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.4.sh
+++ b/18.09.4.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.5.sh
+++ b/18.09.5.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.6.sh
+++ b/18.09.6.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.7.sh
+++ b/18.09.7.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.8.sh
+++ b/18.09.8.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/18.09.9.sh
+++ b/18.09.9.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.0.sh
+++ b/19.03.0.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.1.sh
+++ b/19.03.1.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.10.sh
+++ b/19.03.10.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.11.sh
+++ b/19.03.11.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.12.sh
+++ b/19.03.12.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.13.sh
+++ b/19.03.13.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.14.sh
+++ b/19.03.14.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.2.sh
+++ b/19.03.2.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.3.sh
+++ b/19.03.3.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.4.sh
+++ b/19.03.4.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.5.sh
+++ b/19.03.5.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.7.sh
+++ b/19.03.7.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.8.sh
+++ b/19.03.8.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;

--- a/19.03.9.sh
+++ b/19.03.9.sh
@@ -336,6 +336,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;


### PR DESCRIPTION
Fix for Debian Buster without lsb-release package installed i.e minimal installation.

Note: this pull is related to pull #60 