### PR TITLE
add special case for redhatenterprise

### DIFF
--- a/dist/19.03.13.sh
+++ b/dist/19.03.13.sh
@@ -316,8 +316,8 @@ do_install() {
 
 	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
 
-	# Special case redhatenterpriseserver
-	if [ "${lsb_dist}" = "redhatenterpriseserver" ]; then
+	# Special case redhatenterpriseserver and redhatenterprise
+	if [ "${lsb_dist}" = "redhatenterpriseserver" ] || [ "${lsb_dist}" = "redhatenterprise" ]; then
 		# Set it to redhat, it will be changed to centos below anyways
 		lsb_dist='redhat'
 	fi

--- a/dist/19.03.14.sh
+++ b/dist/19.03.14.sh
@@ -316,8 +316,8 @@ do_install() {
 
 	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
 
-	# Special case redhatenterpriseserver
-	if [ "${lsb_dist}" = "redhatenterpriseserver" ]; then
+	# Special case redhatenterpriseserver and redhatenterprise
+	if [ "${lsb_dist}" = "redhatenterpriseserver" ] || [ "${lsb_dist}" = "redhatenterprise" ]; then
 		# Set it to redhat, it will be changed to centos below anyways
 		lsb_dist='redhat'
 	fi

--- a/dist/19.03.15.sh
+++ b/dist/19.03.15.sh
@@ -316,8 +316,8 @@ do_install() {
 
 	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
 
-	# Special case redhatenterpriseserver
-	if [ "${lsb_dist}" = "redhatenterpriseserver" ]; then
+	# Special case redhatenterpriseserver and redhatenterprise
+	if [ "${lsb_dist}" = "redhatenterpriseserver" ] || [ "${lsb_dist}" = "redhatenterprise" ]; then
 		# Set it to redhat, it will be changed to centos below anyways
 		lsb_dist='redhat'
 	fi


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34007

In RHEL 8.x lsb_release will return `redhatenterprise`, which is not mentioned in the script.