### PR TITLE
added Bullseye to case "$dist_version"

### DIFF
--- a/dist/20.10.7.sh
+++ b/dist/20.10.7.sh
@@ -226,6 +226,9 @@ check_forked() {
 				fi
 				dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 				case "$dist_version" in
+					11)
+						dist_version="bullseye"
+					;;
 					10)
 						dist_version="buster"
 					;;


### PR DESCRIPTION
The Script is not Working on Debian Bullseye, so I added dist_version="bullseye" to the case statement. 