### PR TITLE
Strip versions that are no longer supported

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,9 +33,7 @@ steps:
       branch:
       - master
       event:
-      - push
       - pull_request
-      - tag
 
   - name: add-commit-to-version-file
     image: rancher/dapper:v0.5.4

--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -13,12 +13,11 @@ while true; do
   sleep 5
 done
 
-test_docker_versions["ubuntu:16.04"]="^18.06|^18.09|^19.03|^20.10.[2-7]"
-test_docker_versions["ubuntu:18.04"]="^18.06|^18.09|^19.03|^20.10"
-test_docker_versions["ubuntu:20.04"]="^19.03.9$|^19.03.1[0-9]|^20.10"
-test_docker_versions["centos:centos7"]="^18.06|^18.09|^19.03|^20.10"
+test_docker_versions["ubuntu:18.04"]="^19.03.15$|^20.10"
+test_docker_versions["ubuntu:20.04"]="^^19.03.15$|^20.10"
+test_docker_versions["centos:centos7"]="^19.03.15$|^20.10"
 test_docker_versions["centos:centos8"]="^20.10.[7-9]|^20.10.1[0-9]"
-test_docker_versions["oraclelinux:7"]="^19.03|^20.10"
+test_docker_versions["oraclelinux:7"]="^19.03.15$|^20.10"
 test_docker_versions["oraclelinux:8"]="^20.10"
 test_docker_versions["rockylinux:8"]="^20.10.[8-9]|^20.10.1[0-9]"
 
@@ -37,7 +36,7 @@ for DOCKER_VERSION_SCRIPT in $(find ../dist/ -mindepth 1 -type f -exec basename 
 		if [ -z "${TEST_OS_IMAGE_TAG}" ]; then
 			TEST_OS_IMAGE_TAG[0]="7 8"
 			TEST_OS_IMAGE_TAG[1]="centos7 centos8"
-			TEST_OS_IMAGE_TAG[2]="16.04 18.04 20.04"
+			TEST_OS_IMAGE_TAG[2]="18.04 20.04"
 			TEST_OS_IMAGE_TAG[3]="8"
 			
 		fi


### PR DESCRIPTION
* Remove Ubuntu 16.04 because EOL
* Only test 19.03.15 and 20.10.x because that's what we list in support matrix
* The two changes above bring the test time down from ~50 minutes to ~20 minutes.
* Remove test step on push and tag causing us to move quickly with uploading the files instead of waiting for tests to finish (while they are already tested)