### PR TITLE
Fix test-docker not sourcing config.sh

### DIFF
--- a/pkg/20.10.10/config.sh
+++ b/pkg/20.10.10/config.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-DOCKER_GIT_COMMIT="93d2499759296ac1f9c510605fef85052a2c32be"
-
-TEST_OS_IMAGE_NAME=(oraclelinux centos ubuntu rockylinux)
-TEST_OS_IMAGE_TAG[0]="7 8"
-TEST_OS_IMAGE_TAG[1]="centos7 centos8"
-TEST_OS_IMAGE_TAG[2]="16.04 18.04 20.04"
-TEST_OS_IMAGE_TAG[3]="8"

--- a/pkg/20.10.11/config.sh
+++ b/pkg/20.10.11/config.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-DOCKER_GIT_COMMIT="93d2499759296ac1f9c510605fef85052a2c32be"
-
-TEST_OS_IMAGE_NAME=(oraclelinux centos ubuntu rockylinux)
-TEST_OS_IMAGE_TAG[0]="7 8"
-TEST_OS_IMAGE_TAG[1]="centos7 centos8"
-TEST_OS_IMAGE_TAG[2]="16.04 18.04 20.04"
-TEST_OS_IMAGE_TAG[3]="8"

--- a/pkg/20.10.12/config.sh
+++ b/pkg/20.10.12/config.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-DOCKER_GIT_COMMIT="93d2499759296ac1f9c510605fef85052a2c32be"
-
-TEST_OS_IMAGE_NAME=(oraclelinux centos ubuntu rockylinux)
-TEST_OS_IMAGE_TAG[0]="7 8"
-TEST_OS_IMAGE_TAG[1]="centos7 centos8"
-TEST_OS_IMAGE_TAG[2]="16.04 18.04 20.04"
-TEST_OS_IMAGE_TAG[3]="8"

--- a/pkg/20.10.8/config.sh
+++ b/pkg/20.10.8/config.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-DOCKER_GIT_COMMIT="93d2499759296ac1f9c510605fef85052a2c32be"
-
-TEST_OS_IMAGE_NAME=(oraclelinux centos ubuntu rockylinux)
-TEST_OS_IMAGE_TAG[0]="7 8"
-TEST_OS_IMAGE_TAG[1]="centos7 centos8"
-TEST_OS_IMAGE_TAG[2]="16.04 18.04 20.04"
-TEST_OS_IMAGE_TAG[3]="8"

--- a/pkg/20.10.9/config.sh
+++ b/pkg/20.10.9/config.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-DOCKER_GIT_COMMIT="93d2499759296ac1f9c510605fef85052a2c32be"
-
-TEST_OS_IMAGE_NAME=(oraclelinux centos ubuntu rockylinux)
-TEST_OS_IMAGE_TAG[0]="7 8"
-TEST_OS_IMAGE_TAG[1]="centos7 centos8"
-TEST_OS_IMAGE_TAG[2]="16.04 18.04 20.04"
-TEST_OS_IMAGE_TAG[3]="8"

--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -27,18 +27,15 @@ for DOCKER_VERSION_SCRIPT in $(find ../dist/ -mindepth 1 -type f -exec basename 
 	DOCKER_VERSION=$(echo $DOCKER_VERSION_SCRIPT | sed 's/\.sh//')
         echo "==> Found $DOCKER_VERSION_SCRIPT"
 	if [ -f ../dist/$DOCKER_VERSION_SCRIPT ] ; then
-		if [ -f $DOCKER_VERSION/config.sh ]; then
-			source $DOCKER_VERSION/config.sh
+		if [ -f ../pkg/$DOCKER_VERSION/config.sh ]; then
+			source ../pkg/$DOCKER_VERSION/config.sh
 		fi
-		if [ -z "${TEST_OS_IMAGE_NAME}" ]; then
-                    TEST_OS_IMAGE_NAME=(oraclelinux centos ubuntu rockylinux)
-		fi
-		if [ -z "${TEST_OS_IMAGE_TAG}" ]; then
+		if [ -z "${TEST_OS_IMAGE_NAME}" ] || [ -z "${TEST_OS_IMAGE_TAG}" ]; then
+			TEST_OS_IMAGE_NAME=(oraclelinux centos ubuntu rockylinux)
 			TEST_OS_IMAGE_TAG[0]="7 8"
 			TEST_OS_IMAGE_TAG[1]="centos7 centos8"
 			TEST_OS_IMAGE_TAG[2]="18.04 20.04"
 			TEST_OS_IMAGE_TAG[3]="8"
-			
 		fi
 		for (( index=0; index<${#TEST_OS_IMAGE_NAME[@]}; index++ )); do
 			IMAGE=${TEST_OS_IMAGE_NAME[$index]}

--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -15,6 +15,7 @@ done
 
 test_docker_versions["ubuntu:18.04"]="^19.03.15$|^20.10"
 test_docker_versions["ubuntu:20.04"]="^^19.03.15$|^20.10"
+test_docker_versions["ubuntu:22.04"]="^20.10.13$|^20.10.1[3-9]"
 test_docker_versions["centos:centos7"]="^19.03.15$|^20.10"
 test_docker_versions["centos:centos8"]="^20.10.[7-9]|^20.10.1[0-9]"
 test_docker_versions["oraclelinux:7"]="^19.03.15$|^20.10"
@@ -25,17 +26,21 @@ echo "==> Testing install-docker scripts..."
 
 for DOCKER_VERSION_SCRIPT in $(find ../dist/ -mindepth 1 -type f -exec basename {} \; | sort -V); do
 	DOCKER_VERSION=$(echo $DOCKER_VERSION_SCRIPT | sed 's/\.sh//')
-        echo "==> Found $DOCKER_VERSION_SCRIPT"
+  echo "==> Found $DOCKER_VERSION_SCRIPT"
+  unset TEST_OS_IMAGE_NAME
+  unset TEST_OS_IMAGE_TAG
 	if [ -f ../dist/$DOCKER_VERSION_SCRIPT ] ; then
 		if [ -f ../pkg/$DOCKER_VERSION/config.sh ]; then
 			source ../pkg/$DOCKER_VERSION/config.sh
 		fi
-		if [ -z "${TEST_OS_IMAGE_NAME}" ] || [ -z "${TEST_OS_IMAGE_TAG}" ]; then
+		if [ -z "${TEST_OS_IMAGE_NAME}" ] && [ -z "${TEST_OS_IMAGE_TAG}" ]; then
 			TEST_OS_IMAGE_NAME=(oraclelinux centos ubuntu rockylinux)
 			TEST_OS_IMAGE_TAG[0]="7 8"
 			TEST_OS_IMAGE_TAG[1]="centos7 centos8"
-			TEST_OS_IMAGE_TAG[2]="18.04 20.04"
+			TEST_OS_IMAGE_TAG[2]="18.04 20.04 22.04"
 			TEST_OS_IMAGE_TAG[3]="8"
+		elif [ -z "${TEST_OS_IMAGE_NAME}" ] || [ -z "${TEST_OS_IMAGE_TAG}" ]; then
+		  echo "Both TEST_OS_IMAGE_NAME and TEST_OS_IMAGE_TAG must be set for ${DOCKER_VERSION}"
 		fi
 		for (( index=0; index<${#TEST_OS_IMAGE_NAME[@]}; index++ )); do
 			IMAGE=${TEST_OS_IMAGE_NAME[$index]}


### PR DESCRIPTION
Each script includes `cd $(dirname $0)` at the top, which means the script should be running from it's directory location. Because of this, any overrides to `config.sh` for a specific docker version were being ignored. Also if one of these variables isn't set, we need to set both, because it is not guaranteed that both arrays will line up because the `TEST_OS_IMAGE_TAG` array is not associative.