### PR TITLE
Remove parent directory from upload

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -67,6 +67,7 @@ jobs:
         with:
           path: dist/
           destination: releases.rancher.com/install-docker-dev
+          parent: false
           predefinedAcl: publicRead
           headers: |-
             cache-control: public,no-cache,proxy-revalidate
@@ -99,6 +100,7 @@ jobs:
         with:
           path: dist/
           destination: releases.rancher.com/install-docker
+          parent: false
           predefinedAcl: publicRead
           headers: |-
             cache-control: public,no-cache,proxy-revalidate


### PR DESCRIPTION
Fix upload happening to dist folder in the bucket

> parent - (Optional) Whether parent dir should be included in GCS destination, defaults to true.
> parent: false