### PR TITLE
Remove deprecated Docker version

### DIFF
--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -13,15 +13,15 @@ while true; do
   sleep 5
 done
 
-test_docker_versions["ubuntu:22.04"]="^20.10.24$|^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
+test_docker_versions["ubuntu:22.04"]="^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
 test_docker_versions["ubuntu:24.04"]="^26.0|^26.1|^27.0|^27.1"
 test_docker_versions["quay.io/centos/centos:stream9"]="^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
-test_docker_versions["oraclelinux:8"]="^20.10.24$|^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
-test_docker_versions["oraclelinux:9"]="^20.10.24$|^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
-test_docker_versions["rockylinux:8"]="^20.10.24$|^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
-test_docker_versions["rockylinux:9"]="^20.10.24$|^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
-test_docker_versions["redhat/ubi8:8.9"]="^20.10.24$|^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
-test_docker_versions["redhat/ubi9:9.4"]="^20.10.24$|^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
+test_docker_versions["oraclelinux:8"]="^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
+test_docker_versions["oraclelinux:9"]="^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
+test_docker_versions["rockylinux:8"]="^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
+test_docker_versions["rockylinux:9"]="^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
+test_docker_versions["redhat/ubi8:8.9"]="^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
+test_docker_versions["redhat/ubi9:9.4"]="^23.0.([4-9]|[1-9]\d)$|^24.0|^25.0|^26.0|^26.1|^27.0|^27.1"
 
 echo "==> Testing install-docker scripts..."
 


### PR DESCRIPTION
Eliminate support for deprecated Docker version 20.10 in the testing configuration to ensure compatibility with current standards.